### PR TITLE
Fix error on installing Harmony

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "harmony"]
 	path = harmony
-	url = git@github.com:MythicManiac/harmony.git
+	url = https://github.com/MythicManiac/harmony.git


### PR DESCRIPTION
Harmony is defined in `.gitmodules` through SSH access, which tends to throw errors on initializing Git submodules. I believe this might occur if you don't have some sort of elevated access to the repository.

When trying to Git clone recursively (or cloning non-recursively and initializing submodules after), I get the following output:

```
user@system:~# git clone --recursive https://github.com/LeagueSandbox/IssueBot.git
Cloning into 'IssueBot'...
remote: Counting objects: 123, done.
remote: Total 123 (delta 0), reused 0 (delta 0), pack-reused 123
Receiving objects: 100% (123/123), 38.14 KiB | 0 bytes/s, done.
Resolving deltas: 100% (48/48), done.
Checking connectivity... done.
Submodule 'harmony' (git@github.com:MythicManiac/harmony.git) registered for path 'harmony'
Cloning into 'harmony'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:MythicManiac/harmony.git' into submodule path 'harmony' failed
```

This PR changes the SSH URL in `.gitmodules` into a HTTPS, which uses only read-access (which everyone has), and thus fixes the error above.