### PR TITLE
Add name to config

### DIFF
--- a/issuebot/built/commands/issue.js
+++ b/issuebot/built/commands/issue.js
@@ -2,6 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const issuebot_1 = require("../issuebot");
 const discord_harmony_1 = require("discord-harmony");
+const config = require('../../config.json');
 class IssueCommand extends discord_harmony_1.Command {
     execute() {
         if (!this.args) {
@@ -12,7 +13,7 @@ class IssueCommand extends discord_harmony_1.Command {
             .replace("{CHANNEL}", this.message.channel.name)
             .replace("{USER}", this.message.author.username);
         issuebot_1.default.gitHub.api.issues.create({
-            owner: "LeagueSandbox",
+            owner: config.name,
             repo: this.args[0],
             title: this.args[1],
             body: issueBody

--- a/issuebot/config.json.template
+++ b/issuebot/config.json.template
@@ -1,4 +1,5 @@
 {
   "discordToken": "<insert discord token here>",
-  "githubToken": "<insert github token here>"
+  "githubToken": "<insert github token here>",
+  "name": "<insert github name here>"
 }

--- a/issuebot/src/commands/issue.ts
+++ b/issuebot/src/commands/issue.ts
@@ -1,6 +1,5 @@
 import Bot from '../issuebot'
 import { Command }  from 'discord-harmony'
-import { parseArgs } from 'discord-harmony'
 
 export class IssueCommand extends Command {
   execute() {

--- a/issuebot/src/commands/issue.ts
+++ b/issuebot/src/commands/issue.ts
@@ -1,5 +1,6 @@
 import Bot from '../issuebot'
 import { Command }  from 'discord-harmony'
+const config = require('../../config.json')
 
 export class IssueCommand extends Command {
   execute() {
@@ -11,7 +12,7 @@ export class IssueCommand extends Command {
       .replace("{CHANNEL}", this.message.channel.name)
       .replace("{USER}", this.message.author.username)
     Bot.gitHub.api.issues.create({
-        owner: "LeagueSandbox",
+        owner: config.name,
         repo: this.args[0],
         title: this.args[1],
         body: <any>issueBody // Typings for the `github` package are incorrect, so we have to cast to any here.


### PR DESCRIPTION
https://github.com/LeagueSandbox/IssueBot/blob/15a86931d2c47fc3863e56f2133f74c9ca423853/issuebot/src/commands/issue.ts#L15

By default the value `LeagueSandbox` is hardcoded as the owner when opening a new issue through the GitHub API.

I've been testing with this and it seems that it needs to correspond to either a GitHub user or GitHub organization to be able to work.

Trying out the bot in my server using this default owner name resulted in a 404 from GitHub:

![screenshot_20180804_202601](https://user-images.githubusercontent.com/1611537/43679404-c16423ec-9824-11e8-83c5-ff17b62b698a.png)

Changing the hardcoded value to my GitHub username fixed it for me.

This PR makes the owner name configurable, and thus fixing this issue.

Note that if you merge this PR and update your bot, you should add `"name": "LeagueSandbox"` to your config.json.