### PR TITLE
Change link harmony after install instead of before

### DIFF
--- a/issuebot/package.json
+++ b/issuebot/package.json
@@ -7,7 +7,7 @@
     "watch": "tsc -p . -w",
     "start": "tsc -p . && node built/issuebot.js",
     "test": "echo \"No tests specified\"",
-    "preinstall": "npm link ../harmony"
+    "postinstall": "npm link ../harmony"
   },
   "keywords": [],
   "author": "LeagueSandbox https://github.com/LeagueSandbox",


### PR DESCRIPTION
Current scenario is that `npm link ../harmony` runs before `npm install`, the latter which removes any dependencies not defined in its `package.json`, i.e. the `node_modules/discord-harmony` symlink.

This PR changes npm linking from preinstall to postinstall, which allows you to just run `npm install` to install dependencies, keeping the discord-harmony symlink in tact, and thus fixing the above issue.